### PR TITLE
feat: Add Proxmox Backup Provider

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupExecutionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupExecutionProvider.groovy
@@ -1,0 +1,233 @@
+package com.morpheusdata.proxmox.ve
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.backup.BackupExecutionProvider
+import com.morpheusdata.core.backup.response.BackupExecutionResponse
+import com.morpheusdata.core.util.DateUtility
+import com.morpheusdata.model.Backup
+import com.morpheusdata.model.BackupResult
+import com.morpheusdata.model.Cloud
+import com.morpheusdata.model.ComputeServer
+import com.morpheusdata.model.Workload
+import com.morpheusdata.response.ServiceResponse
+import com.morpheusdata.proxmox.ve.util.ProxmoxApiBackupUtil
+import com.morpheusdata.core.util.HttpApiClient
+import groovy.util.logging.Slf4j
+import java.util.Date
+
+@Slf4j
+class ProxmoxBackupExecutionProvider implements BackupExecutionProvider {
+
+    ProxmoxVePlugin plugin
+    MorpheusContext morpheusContext
+
+    ProxmoxBackupExecutionProvider(ProxmoxVePlugin plugin, MorpheusContext morpheusContext) {
+        this.plugin = plugin
+        this.morpheusContext = morpheusContext
+    }
+    
+    MorpheusContext getMorpheus() {
+        return morpheusContext
+    }
+
+    @Override
+    ServiceResponse configureBackup(Backup backup, Map config, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.configureBackup for backup: ${backup.name}, config: ${config}, opts: ${opts}")
+        return ServiceResponse.success(backup)
+    }
+
+    @Override
+    ServiceResponse validateBackup(Backup backup, Map config, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.validateBackup for backup: ${backup.name}, config: ${config}, opts: ${opts}")
+        return ServiceResponse.success(backup)
+    }
+
+    @Override
+    ServiceResponse createBackup(Backup backup, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.createBackup for backup: ${backup.name}, opts: ${opts}")
+        return ServiceResponse.success()
+    }
+
+    @Override
+    ServiceResponse deleteBackup(Backup backup, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.deleteBackup for backup: ${backup.name}, opts: ${opts}")
+        return ServiceResponse.success()
+    }
+
+    @Override
+    ServiceResponse deleteBackupResult(BackupResult backupResult, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.deleteBackupResult for backupResult id: ${backupResult.id}, opts: ${opts}")
+        ServiceResponse rtn = ServiceResponse.prepare()
+        HttpApiClient client = new HttpApiClient()
+        try {
+            def config = backupResult.getConfigMap() ?: [:]
+            Cloud cloud = morpheusContext.services.cloud.get(backupResult.backup.cloud.id).blockingGet()
+            ComputeServer server = null
+            if(backupResult.server?.id) {
+                server = morpheusContext.services.computeServer.get(backupResult.server.id).blockingGet()
+            } else if(backupResult.containerId) {
+                Workload container = morpheusContext.services.workload.get(backupResult.containerId).blockingGet()
+                if(container?.serverId) {
+                    server = morpheusContext.services.computeServer.get(container.serverId).blockingGet()
+                }
+            }
+
+            def snapshotName = backupResult.snapshotId ?: config.snapshotId
+
+            if (!cloud) {
+                 rtn.setSuccess(false)
+                 rtn.setMsg("Cloud not found for backup result ${backupResult.id}")
+                 log.error(rtn.msg)
+                 return rtn
+            }
+            if (!server) {
+                rtn.setSuccess(false)
+                rtn.setMsg("Server not found for backup result ${backupResult.id}")
+                log.error(rtn.msg)
+                return rtn
+            }
+            if (!snapshotName) {
+                rtn.setSuccess(false)
+                rtn.setMsg("Snapshot name/ID not found in backup result ${backupResult.id}")
+                log.error(rtn.msg)
+                return rtn
+            }
+
+            def authConfig = plugin.getAuthConfig(cloud)
+            // TODO: Review and enhance proxmoxNode determination for robustness across various server/setup configurations.
+            String proxmoxNode = server.parentServer?.name ?: server.parentServer?.externalId
+            if(!proxmoxNode && server.parentServerId) {
+                ComputeServer parentSrv = morpheusContext.services.computeServer.get(server.parentServerId).blockingGet()
+                proxmoxNode = parentSrv?.name ?: parentSrv?.externalId
+            }
+            if(!proxmoxNode) {
+                 proxmoxNode = server.getConfigProperty('proxmoxNode')
+            }
+             if(!proxmoxNode) { // Fallback to config map on backup result itself
+                proxmoxNode = config.proxmoxNode
+            }
+
+
+            if (!proxmoxNode) {
+                rtn.setSuccess(false)
+                rtn.setMsg("Proxmox node not found for server ${server.name} (${server.id}) for backup result ${backupResult.id}")
+                log.error(rtn.msg)
+                return rtn
+            }
+
+            log.info("Attempting to delete Proxmox snapshot: '${snapshotName}' for VM ID: ${server.externalId} on node: ${proxmoxNode}")
+            ServiceResponse deleteSnapResponse = ProxmoxApiBackupUtil.deleteSnapshot(client, authConfig, proxmoxNode, server.externalId, snapshotName)
+
+            if (deleteSnapResponse.success) {
+                log.info("Successfully deleted snapshot '${snapshotName}' from Proxmox for backup result ${backupResult.id}")
+                rtn.setSuccess(true)
+            } else {
+                log.error("Failed to delete snapshot '${snapshotName}' from Proxmox: ${deleteSnapResponse.msg}")
+                rtn.setSuccess(false)
+                rtn.setMsg("Failed to delete snapshot from Proxmox: ${deleteSnapResponse.msg}")
+            }
+        } catch (Exception e) {
+            log.error("Error in deleteBackupResult for Proxmox: ${e.message}", e)
+            rtn.setSuccess(false)
+            rtn.setMsg("Error deleting Proxmox snapshot: ${e.message}")
+        } finally {
+            client?.shutdownClient()
+        }
+        return rtn
+    }
+
+    @Override
+    ServiceResponse prepareExecuteBackup(Backup backup, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.prepareExecuteBackup for backup: ${backup.name}, opts: ${opts}")
+        return ServiceResponse.success()
+    }
+
+    @Override
+    ServiceResponse prepareBackupResult(BackupResult backupResultModel, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.prepareBackupResult for backupResult id: ${backupResultModel.id}, opts: ${opts}")
+        return ServiceResponse.success()
+    }
+
+    @Override
+    ServiceResponse<BackupExecutionResponse> executeBackup(Backup backup, BackupResult backupResult, Map executionConfig, Cloud cloud, ComputeServer server, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.executeBackup for backup: ${backup.name}, server: ${server.name}, executionConfig: ${executionConfig}, opts: ${opts}")
+        ServiceResponse<BackupExecutionResponse> rtn = ServiceResponse.prepare(new BackupExecutionResponse(backupResult))
+        HttpApiClient client = new HttpApiClient()
+        try {
+            backupResult.status = BackupResult.Status.IN_PROGRESS
+            morpheusContext.async.backup.saveResult(backupResult).blockingGet()
+
+            def snapshotName = "morpheus-${backup.id}-${System.currentTimeMillis()}"
+            def description = "Morpheus Backup: ${backup.name} for server ${server.name} (${server.id}) - ${new Date().toString()}"
+            
+            def authConfig = plugin.getAuthConfig(cloud)
+            // TODO: Review and enhance proxmoxNode determination for robustness across various server/setup configurations.
+            String proxmoxNode = server.parentServer?.name ?: server.parentServer?.externalId
+             if(!proxmoxNode && server.parentServerId) {
+                ComputeServer parentSrv = morpheusContext.services.computeServer.get(server.parentServerId).blockingGet()
+                proxmoxNode = parentSrv?.name ?: parentSrv?.externalId
+            }
+            if(!proxmoxNode) {
+                 proxmoxNode = server.getConfigProperty('proxmoxNode')
+            }
+
+            if (!proxmoxNode) {
+                throw new IllegalStateException("Proxmox node not found for server ${server.name} (${server.id})")
+            }
+            
+            log.info("Attempting to create Proxmox snapshot: '${snapshotName}' for VM ID: ${server.externalId} on node: ${proxmoxNode}. Description: '${description}'")
+            ServiceResponse createSnapResponse = ProxmoxApiBackupUtil.createSnapshot(client, authConfig, proxmoxNode, server.externalId, snapshotName, description)
+
+            if (createSnapResponse.success) {
+                log.info("Successfully created snapshot '${snapshotName}' in Proxmox. Task ID: ${createSnapResponse.data?.data}")
+                backupResult.snapshotId = snapshotName 
+                backupResult.externalId = createSnapResponse.data?.data // Proxmox task ID
+                backupResult.status = BackupResult.Status.SUCCEEDED
+                backupResult.setConfigProperty("proxmoxNode", proxmoxNode)
+                backupResult.setConfigProperty("vmExternalId", server.externalId)
+                backupResult.setConfigProperty("snapshotDescription", description)
+            } else {
+                log.error("Failed to create snapshot '${snapshotName}' in Proxmox: ${createSnapResponse.msg}")
+                backupResult.status = BackupResult.Status.FAILED
+                backupResult.errorOutput = createSnapResponse.msg?.encodeAsBase64()
+            }
+        } catch (Exception e) {
+            log.error("Error in executeBackup for Proxmox: ${e.message}", e)
+            backupResult.status = BackupResult.Status.FAILED
+            backupResult.errorOutput = e.message?.encodeAsBase64()
+            rtn.setSuccess(false)
+            rtn.setMsg(e.message)
+        } finally {
+            backupResult.endDate = new Date()
+            if (backupResult.startDate) {
+                def start = backupResult.startDate
+                def end = backupResult.endDate
+                backupResult.durationMillis = end.time - start.time
+            }
+            morpheusContext.async.backup.saveResult(backupResult).blockingGet()
+            rtn.data.backupResult = backupResult
+            client?.shutdownClient()
+        }
+        rtn.setSuccess(backupResult.status == BackupResult.Status.SUCCEEDED)
+        return rtn
+    }
+
+    @Override
+    ServiceResponse<BackupExecutionResponse> refreshBackupResult(BackupResult backupResult) {
+        log.debug("ProxmoxBackupExecutionProvider.refreshBackupResult for backupResult id: ${backupResult.id}")
+        // TODO: Implement if Proxmox snapshot creation is asynchronous and needs status polling.
+        return ServiceResponse.success(new BackupExecutionResponse(backupResult))
+    }
+    
+    @Override
+    ServiceResponse cancelBackup(BackupResult backupResultModel, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.cancelBackup for backupResult id: ${backupResultModel.id}, opts: ${opts}")
+        return ServiceResponse.error("Snapshot cancellation not supported by Proxmox provider.")
+    }
+
+    @Override
+    ServiceResponse extractBackup(BackupResult backupResultModel, Map opts) {
+        log.debug("ProxmoxBackupExecutionProvider.extractBackup for backupResult id: ${backupResultModel.id}, opts: ${opts}")
+        return ServiceResponse.error("Snapshot extraction not supported by Proxmox provider.")
+    }
+}

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupProvider.groovy
@@ -1,0 +1,19 @@
+package com.morpheusdata.proxmox.ve
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.backup.BackupJobProvider
+import com.morpheusdata.core.backup.MorpheusBackupProvider
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class ProxmoxBackupProvider extends MorpheusBackupProvider {
+
+    ProxmoxBackupProvider(ProxmoxVePlugin plugin, MorpheusContext morpheusContext) {
+        super(plugin, morpheusContext)
+
+        ProxmoxBackupTypeProvider backupTypeProvider = new ProxmoxBackupTypeProvider(plugin, morpheus)
+        plugin.registerProvider(backupTypeProvider)
+        // TODO: Verify scope, "proxmox" should match the cloud code or a specific Proxmox VM provision type code.
+        addScopedProvider(backupTypeProvider, "proxmox", null) 
+    }
+}

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupRestoreProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupRestoreProvider.groovy
@@ -1,0 +1,134 @@
+package com.morpheusdata.proxmox.ve
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.backup.BackupRestoreProvider
+import com.morpheusdata.core.backup.response.BackupRestoreResponse
+import com.morpheusdata.model.BackupResult
+import com.morpheusdata.model.Cloud
+import com.morpheusdata.model.ComputeServer
+import com.morpheusdata.model.Instance
+import com.morpheusdata.model.Workload
+import com.morpheusdata.response.ServiceResponse
+import com.morpheusdata.proxmox.ve.util.ProxmoxApiBackupUtil
+import com.morpheusdata.core.util.HttpApiClient
+import groovy.util.logging.Slf4j
+import java.util.Date
+
+@Slf4j
+class ProxmoxBackupRestoreProvider implements BackupRestoreProvider {
+
+    ProxmoxVePlugin plugin
+    MorpheusContext morpheusContext
+
+    ProxmoxBackupRestoreProvider(ProxmoxVePlugin plugin, MorpheusContext morpheusContext) {
+        this.plugin = plugin
+        this.morpheusContext = morpheusContext
+    }
+
+    MorpheusContext getMorpheus() {
+        return morpheusContext
+    }
+
+    @Override
+    ServiceResponse validateRestore(BackupResult backupResult, Instance instance, ComputeServer server, Map config, Map opts) {
+        log.debug("ProxmoxBackupRestoreProvider.validateRestore for backupResult: ${backupResult.id}, instance: ${instance?.name}, server: ${server?.name}")
+        if (!backupResult.snapshotId && !(backupResult.getConfigMap()?.snapshotId)) {
+            return ServiceResponse.error("Snapshot ID not found in BackupResult, cannot restore.")
+        }
+        return ServiceResponse.success()
+    }
+
+    @Override
+    ServiceResponse prepareRestore(BackupResult backupResult, Instance instance, ComputeServer server, Map config, Map opts) {
+        log.debug("ProxmoxBackupRestoreProvider.prepareRestore for backupResult: ${backupResult.id}")
+        return ServiceResponse.success()
+    }
+
+    @Override
+    ServiceResponse<BackupRestoreResponse> executeRestore(BackupResult backupResult, Instance instance, Workload workload, ComputeServer server, Map<String,Object> config, Map<String,Object> opts) {
+        log.debug("ProxmoxBackupRestoreProvider.executeRestore for backupResult: ${backupResult.id} to server: ${server.name}")
+        ServiceResponse<BackupRestoreResponse> rtn = ServiceResponse.prepare(new BackupRestoreResponse(backupResult))
+        HttpApiClient client = new HttpApiClient()
+        try {
+            // TODO: Implement proper persistence of restore status, errors, and dates on BackupResult.
+            // Example: backupResult.restoreStatus = ...; backupResult.restoreError = ...; backupResult.restoreEndDate = new Date(); morpheusContext.async.backup.saveResult(backupResult).blockingGet();
+            // backupResult.status = BackupResult.Status.IN_PROGRESS // This is for backup status, not restore.
+
+            def snapshotName = backupResult.snapshotId ?: backupResult.getConfigMap()?.snapshotId
+            if (!snapshotName) {
+                throw new IllegalStateException("Snapshot name/ID not found in backup result ${backupResult.id}")
+            }
+
+            def cloud = morpheusContext.services.cloud.get(server.cloud.id).blockingGet()
+            def authConfig = plugin.getAuthConfig(cloud)
+            
+            // TODO: Review and enhance proxmoxNode determination for robustness across various server/setup configurations.
+            String proxmoxNode = server.parentServer?.name ?: server.parentServer?.externalId
+            if(!proxmoxNode && server.parentServerId) {
+                ComputeServer parentSrv = morpheusContext.services.computeServer.get(server.parentServerId).blockingGet()
+                proxmoxNode = parentSrv?.name ?: parentSrv?.externalId
+            }
+            if(!proxmoxNode) {
+                 proxmoxNode = server.getConfigProperty('proxmoxNode') ?: backupResult.getConfigMap()?.proxmoxNode
+            }
+            
+            if (!proxmoxNode) {
+                throw new IllegalStateException("Proxmox node not found for server ${server.name} (${server.id})")
+            }
+
+            log.info("Attempting to roll back Proxmox snapshot: '${snapshotName}' for VM ID: ${server.externalId} on node: ${proxmoxNode}")
+            ServiceResponse rollbackResponse = ProxmoxApiBackupUtil.rollbackSnapshot(client, authConfig, proxmoxNode, server.externalId, snapshotName)
+
+            if (rollbackResponse.success) {
+                log.info("Successfully initiated rollback of snapshot '${snapshotName}' in Proxmox. Task ID: ${rollbackResponse.data?.data}")
+                // TODO: Verify Proxmox behavior: Does VM need to be manually started after rollback? If so, implement server start.
+                // Example: plugin.getProvider(ProxmoxVeProvisionProvider.PROVISION_PROVIDER_CODE).startServer(server)
+                // TODO: If rollback is asynchronous, store task ID (rollbackResponse.data.data) on backupResult for polling in refreshRestore.
+            } else {
+                log.error("Failed to rollback snapshot '${snapshotName}' in Proxmox: ${rollbackResponse.msg}")
+                rtn.setSuccess(false) // Ensure overall response reflects failure
+                rtn.setMsg(rollbackResponse.msg)
+            }
+
+        } catch (Exception e) {
+            log.error("Error in executeRestore for Proxmox: ${e.message}", e)
+            rtn.setSuccess(false)
+            rtn.setMsg(e.message)
+        } finally {
+            // TODO: Ensure restore status (success/failure), error message, and duration are saved on backupResult (see TODO at start of try block).
+            rtn.data.backupResult = backupResult
+            client?.shutdownClient()
+        }
+         // if rtn success was not set to false explicitly, it defaults to true from prepare()
+        if(rtn.msg != null && rtn.success) { // if there's a message but success is still true, it's likely an error
+            rtn.setSuccess(false)
+        } else if (rtn.msg == null && !rtn.success) { // if no message but success is false
+             rtn.setMsg("Restore failed due to an unspecified error.")
+        } else if (rtn.success && rtn.msg == null) {
+             // If successful and no message was set, provide a generic success message
+             rtn.setMsg("Restore operation completed successfully.")
+        }
+        return rtn
+    }
+
+    @Override
+    ServiceResponse<BackupRestoreResponse> refreshRestore(BackupResult backupResult, Instance instance, ComputeServer server, Map opts) {
+        log.debug("ProxmoxBackupRestoreProvider.refreshRestore for backupResult: ${backupResult.id}")
+        // TODO: Implement if Proxmox snapshot rollback is asynchronous.
+        return ServiceResponse.success(new BackupRestoreResponse(backupResult))
+    }
+
+    @Override
+    ServiceResponse failRestore(BackupResult backupResult, Instance instance, ComputeServer server, Map opts) {
+        log.debug("ProxmoxBackupRestoreProvider.failRestore for backupResult: ${backupResult.id}")
+        // backupResult.restoreStatus = BackupResult.Status.FAILED // Example
+        // morpheusContext.async.backup.saveResult(backupResult).blockingGet() 
+        return ServiceResponse.success()
+    }
+
+    @Override
+    ServiceResponse cleanupRestore(BackupResult backupResult, Instance instance, ComputeServer server, Map opts) {
+        log.debug("ProxmoxBackupRestoreProvider.cleanupRestore for backupResult: ${backupResult.id}")
+        return ServiceResponse.success()
+    }
+}

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupTypeProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupTypeProvider.groovy
@@ -1,0 +1,112 @@
+package com.morpheusdata.proxmox.ve
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.backup.AbstractBackupTypeProvider
+import com.morpheusdata.core.backup.BackupExecutionProvider
+import com.morpheusdata.core.backup.BackupRestoreProvider
+import com.morpheusdata.model.BackupProvider as BackupProviderModel
+import com.morpheusdata.model.OptionType
+import com.morpheusdata.response.ServiceResponse
+import groovy.util.logging.Slf4j
+import java.util.ArrayList
+import java.util.Collection
+
+@Slf4j
+class ProxmoxBackupTypeProvider extends AbstractBackupTypeProvider {
+
+    ProxmoxBackupExecutionProvider executionProvider
+    ProxmoxBackupRestoreProvider restoreProvider
+    MorpheusContext morpheusContext
+    ProxmoxVePlugin plugin
+
+    ProxmoxBackupTypeProvider(ProxmoxVePlugin plugin, MorpheusContext morpheusContext) {
+        super(plugin, morpheusContext)
+        this.plugin = plugin
+        this.morpheusContext = morpheusContext
+    }
+
+    @Override
+    String getCode() {
+        return "proxmoxSnapshot"
+    }
+
+    @Override
+    String getName() {
+        return "Proxmox VM Snapshot"
+    }
+    
+    @Override
+    String getContainerType() {
+        return "single" // Typically for VM snapshots
+    }
+    
+    @Override
+    Boolean getCopyToStore() {
+        return false // Proxmox snapshots are typically stored on the same storage as the VM
+    }
+
+    @Override
+    Boolean getDownloadEnabled() {
+        return false // Direct download of Proxmox snapshots is not a standard feature via this mechanism
+    }
+
+    @Override
+    Boolean getRestoreExistingEnabled() {
+        return true // Snapshots can be rolled back to the existing VM
+    }
+
+    @Override
+    Boolean getRestoreNewEnabled() {
+        return false // Restoring a snapshot to a new VM (clone from snapshot) might be possible but not implemented initially
+    }
+
+    @Override
+    String getRestoreType() {
+        return "offline" // Snapshot rollback usually requires VM to be offline or reboots
+    }
+
+    @Override
+    String getRestoreNewMode() {
+        return null // Not applicable as getRestoreNewEnabled is false
+    }
+    
+    @Override
+    Boolean getHasCopyToStore() {
+        return false
+    }
+
+    @Override
+    Collection<OptionType> getOptionTypes() {
+        return new ArrayList<OptionType>() // No specific options for snapshot creation initially
+    }
+    
+    @Override
+    ProxmoxBackupExecutionProvider getExecutionProvider() {
+        if(this.executionProvider == null) {
+            this.executionProvider = new ProxmoxBackupExecutionProvider(plugin, morpheusContext)
+        }
+        return this.executionProvider
+    }
+
+    @Override
+    ProxmoxBackupRestoreProvider getRestoreProvider() {
+        if(this.restoreProvider == null) {
+            this.restoreProvider = new ProxmoxBackupRestoreProvider(plugin, morpheusContext)
+        }
+        return this.restoreProvider
+    }
+
+    @Override
+    ServiceResponse refresh(Map authConfig, BackupProviderModel backupProviderModel) {
+        log.debug("ProxmoxBackupTypeProvider.refresh called for backupProviderModel: ${backupProviderModel?.name}")
+        // TODO: Implement if any specific refresh logic is needed from Proxmox for this backup type
+        return ServiceResponse.success()
+    }
+    
+    @Override
+    ServiceResponse clean(BackupProviderModel backupProviderModel, Map opts) {
+        log.debug("ProxmoxBackupTypeProvider.clean called for backupProviderModel: ${backupProviderModel?.name}")
+        // TODO: Implement if any specific cleanup logic is needed when the backup provider integration is removed
+        return ServiceResponse.success()
+    }
+}

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVePlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVePlugin.groovy
@@ -38,6 +38,7 @@ class ProxmoxVePlugin extends Plugin {
         this.registerProvider(new ProxmoxVeProvisionProvider(this, this.morpheus))
         this.registerProvider(new ProxmoxVeOptionSourceProvider(this, this.morpheus))
         this.registerProvider(new ProxmoxVeVirtualImageDatasetProvider(this, this.morpheus))
+        this.registerProvider(new ProxmoxBackupProvider(this, this.morpheus))
         def networkProvider = new ProxmoxNetworkProvider(this, this.morpheus)
         this.registerProvider(networkProvider)
         networkProviderCode = networkProvider.code

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiBackupUtil.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiBackupUtil.groovy
@@ -1,0 +1,203 @@
+package com.morpheusdata.proxmox.ve.util
+
+import com.morpheusdata.core.util.HttpApiClient
+import com.morpheusdata.response.ServiceResponse
+import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
+import org.apache.http.entity.ContentType
+
+import java.net.URLEncoder
+
+@Slf4j
+class ProxmoxApiBackupUtil {
+
+    // Method adapted from ProxmoxApiComputeUtil.groovy
+    private static ServiceResponse getApiV2Token(Map authConfig) {
+        def path = "access/ticket"
+        log.debug("ProxmoxApiBackupUtil.getApiV2Token: path: \${path} for apiUrl: \${authConfig.apiUrl}")
+        HttpApiClient client = new HttpApiClient() // Local client for token retrieval
+        def rtn = new ServiceResponse(success: false)
+        try {
+            def encUid = URLEncoder.encode((String) authConfig.username, "UTF-8")
+            def encPwd = URLEncoder.encode((String) authConfig.password, "UTF-8")
+            def bodyStr = "username=" + "\${encUid}" + "&password=\${encPwd}"
+
+            HttpApiClient.RequestOptions opts = new HttpApiClient.RequestOptions(
+                    headers: ['Content-Type':'application/x-www-form-urlencoded'],
+                    body: bodyStr,
+                    contentType: ContentType.APPLICATION_FORM_URLENCODED,
+                    ignoreSSL: true // TODO: Make this configurable based on cloud settings if possible
+            )
+            def results = client.callJsonApi(authConfig.apiUrl,"${authConfig.v2basePath}/\${path}", opts, 'POST')
+
+            log.debug("getApiV2Token API request results: \${results.toMap()}")
+            if(results?.success && !results?.hasErrors() && results.data?.data) {
+                rtn.success = true
+                def tokenData = results.data.data
+                rtn.data = [csrfToken: tokenData.CSRFPreventionToken, token: tokenData.ticket]
+            } else {
+                rtn.success = false
+                rtn.msg = "Error retrieving token: \${results.data ?: results.content}"
+                log.error("Error retrieving token: \${rtn.msg}")
+            }
+        } catch(e) {
+            log.error "Error in getApiV2Token: \${e.message}", e
+            rtn.msg = "Error in getApiV2Token: \${e.message}"
+            rtn.success = false
+        } finally {
+            client.shutdownClient() // Shutdown the local client used for token retrieval
+        }
+        return rtn
+    }
+
+    static ServiceResponse createSnapshot(HttpApiClient client, Map authConfig, String nodeId, String vmId, String snapshotName, String description) {
+        log.debug("ProxmoxApiBackupUtil.createSnapshot: nodeId=\${nodeId}, vmId=\${vmId}, snapshotName='\${snapshotName}', description='\${description}'")
+        ServiceResponse tokenResponse = getApiV2Token(authConfig)
+        if (!tokenResponse.success) {
+            return tokenResponse // Return error if token retrieval failed
+        }
+        def tokenCfg = tokenResponse.data
+        def rtn = new ServiceResponse(success: false)
+
+        try {
+            def path = "nodes/\${nodeId}/qemu/\${vmId}/snapshot"
+            def bodyPayload = [snapname: snapshotName]
+            if (description != null && !description.isEmpty()) {
+                bodyPayload.description = description
+            }
+            // Proxmox API for snapshot creation might require 'vmstatestore' parameter if the VM is running and live snapshot is desired.
+            // For simplicity, assuming default behavior or that VM is offline if needed.
+            // Add 'vmstatestore': 1 for live snapshots if required and supported.
+            // bodyPayload.vmstatestore = 1 // Example for live snapshot, check Proxmox docs
+            // TODO: Investigate and confirm Proxmox API requirements for 'vmstatestore' (live snapshots) and consider making it a user option.
+
+            HttpApiClient.RequestOptions opts = new HttpApiClient.RequestOptions(
+                headers: [
+                    'Cookie': "PVEAuthCookie=\${tokenCfg.token}",
+                    'CSRFPreventionToken': tokenCfg.csrfToken
+                ],
+                body: bodyPayload,
+                contentType: ContentType.APPLICATION_JSON, // TODO: Verify Content-Type; Proxmox might expect x-www-form-urlencoded for this operation.
+                ignoreSSL: true // TODO: Make this configurable
+            )
+
+            log.info("Creating Proxmox snapshot. API POST to \${authConfig.apiUrl}\${authConfig.v2basePath}/\${path} with body: \${bodyPayload}")
+            def results = client.callJsonApi(authConfig.apiUrl, "\${authConfig.v2basePath}/\${path}", null, null, opts, 'POST')
+            log.debug("Create snapshot API response: \${results.toMap()}")
+
+            if (results?.success && results.data?.data) {
+                rtn.success = true
+                rtn.data = results.data // Usually contains the task ID
+                rtn.msg = "Snapshot creation initiated successfully. Task ID: \${results.data.data}"
+            } else {
+                rtn.success = false
+                rtn.msg = "Failed to create snapshot: \${results.msg ?: results.content}"
+                log.error(rtn.msg)
+            }
+        } catch (Exception e) {
+            log.error("Exception during createSnapshot: \${e.message}", e)
+            rtn.success = false
+            rtn.msg = "Exception creating snapshot: \${e.message}"
+        }
+        return rtn
+    }
+
+    static ServiceResponse deleteSnapshot(HttpApiClient client, Map authConfig, String nodeId, String vmId, String snapshotName) {
+        log.debug("ProxmoxApiBackupUtil.deleteSnapshot: nodeId=\${nodeId}, vmId=\${vmId}, snapshotName='\${snapshotName}'")
+        ServiceResponse tokenResponse = getApiV2Token(authConfig)
+        if (!tokenResponse.success) {
+            return tokenResponse
+        }
+        def tokenCfg = tokenResponse.data
+        def rtn = new ServiceResponse(success: false)
+
+        try {
+            def path = "nodes/\${nodeId}/qemu/\${vmId}/snapshot/\${snapshotName}"
+            HttpApiClient.RequestOptions opts = new HttpApiClient.RequestOptions(
+                headers: [
+                    'Cookie': "PVEAuthCookie=\${tokenCfg.token}",
+                    'CSRFPreventionToken': tokenCfg.csrfToken
+                ],
+                ignoreSSL: true // TODO: Make this configurable
+            )
+
+            log.info("Deleting Proxmox snapshot. API DELETE to \${authConfig.apiUrl}\${authConfig.v2basePath}/\${path}")
+            def results = client.callJsonApi(authConfig.apiUrl, "\${authConfig.v2basePath}/\${path}", null, null, opts, 'DELETE')
+            log.debug("Delete snapshot API response: \${results.toMap()}")
+
+            if (results?.success && results.data?.data) {
+                rtn.success = true
+                rtn.data = results.data // Usually contains the task ID
+                rtn.msg = "Snapshot deletion initiated successfully. Task ID: \${results.data.data}"
+            } else {
+                // Proxmox might return 200 OK with null data on successful deletion, or if snapshot doesn't exist.
+                // Or it might return an error if it fails. This needs testing.
+                // If result.success is true but no data, assume it worked.
+                if(results?.success) {
+                     rtn.success = true
+                     rtn.msg = "Snapshot deletion request processed. Proxmox response indicated success."
+                } else {
+                    rtn.success = false
+                    rtn.msg = "Failed to delete snapshot: \${results.msg ?: results.content}"
+                    log.error(rtn.msg)
+                }
+            }
+        } catch (Exception e) {
+            log.error("Exception during deleteSnapshot: \${e.message}", e)
+            rtn.success = false
+            rtn.msg = "Exception deleting snapshot: \${e.message}"
+        }
+        return rtn
+    }
+    
+    static ServiceResponse rollbackSnapshot(HttpApiClient client, Map authConfig, String nodeId, String vmId, String snapshotName) {
+        log.debug("ProxmoxApiBackupUtil.rollbackSnapshot: nodeId=\${nodeId}, vmId=\${vmId}, snapshotName='\${snapshotName}'")
+        ServiceResponse tokenResponse = getApiV2Token(authConfig)
+        if (!tokenResponse.success) {
+            return tokenResponse
+        }
+        def tokenCfg = tokenResponse.data
+        def rtn = new ServiceResponse(success: false)
+
+        try {
+            // Proxmox API to rollback a snapshot is a POST to the snapshot name itself
+            def path = "nodes/\${nodeId}/qemu/\${vmId}/snapshot/\${snapshotName}/rollback" 
+            // The body for rollback is typically empty or might take a parameter like 'start': 1 to start the VM after rollback.
+            // For now, assuming an empty body.
+            def bodyPayload = [:] 
+
+            HttpApiClient.RequestOptions opts = new HttpApiClient.RequestOptions(
+                headers: [
+                    'Cookie': "PVEAuthCookie=\${tokenCfg.token}",
+                    'CSRFPreventionToken': tokenCfg.csrfToken
+                ],
+                body: bodyPayload, 
+                contentType: ContentType.APPLICATION_JSON, // TODO: Verify Content-Type; Proxmox might expect x-www-form-urlencoded for this operation.
+                ignoreSSL: true // TODO: Make this configurable
+            )
+
+            log.info("Rolling back Proxmox snapshot. API POST to \${authConfig.apiUrl}\${authConfig.v2basePath}/\${path}")
+            def results = client.callJsonApi(authConfig.apiUrl, "\${authConfig.v2basePath}/\${path}", null, null, opts, 'POST')
+            log.debug("Rollback snapshot API response: \${results.toMap()}")
+
+            if (results?.success && results.data?.data) {
+                rtn.success = true
+                rtn.data = results.data // Usually contains the task ID
+                rtn.msg = "Snapshot rollback initiated successfully. Task ID: \${results.data.data}"
+            } else {
+                rtn.success = false
+                rtn.msg = "Failed to rollback snapshot: \${results.msg ?: results.content}"
+                log.error(rtn.msg)
+            }
+        } catch (Exception e) {
+            log.error("Exception during rollbackSnapshot: \${e.message}", e)
+            rtn.success = false
+            rtn.msg = "Exception rolling back snapshot: \${e.message}"
+        }
+        return rtn
+    }
+
+    // Optional: Methods for getSnapshot and listSnapshots can be added here if needed later.
+    // static ServiceResponse getSnapshot(HttpApiClient client, Map authConfig, String nodeId, String vmId, String snapshotName) { ... }
+    // static ServiceResponse listSnapshots(HttpApiClient client, Map authConfig, String nodeId, String vmId) { ... }
+}


### PR DESCRIPTION
This commit introduces a backup provider for Proxmox VE, enabling you to create and restore VM snapshots.

Key additions include:
- ProxmoxBackupProvider: Registers the backup functionality.
- ProxmoxBackupTypeProvider: Defines the "Proxmox VM Snapshot" backup type.
- ProxmoxBackupExecutionProvider: Handles the execution of snapshot creation and deletion.
- ProxmoxBackupRestoreProvider: Manages the restoration (rollback) of VM snapshots.
- ProxmoxApiBackupUtil: A new utility class to interact with the Proxmox API for snapshot-specific operations (create, delete, rollback).

The implementation is based on the SCVMM backup provider example and includes TODO comments for areas that may require further refinement, such as asynchronous task handling, Proxmox API specific configurations (e.g., live snapshots), and detailed error mapping.

The new backup provider is registered in the ProxmoxVePlugin.