### PR TITLE
Clean up actionVMStatus apiPath

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiComputeUtil.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiComputeUtil.groovy
@@ -38,7 +38,6 @@ class ProxmoxApiComputeUtil {
             ]
 
             log.debug("Setting VM Compute Size $vmId on node $node...")
-            log.debug("POST path is: $authConfig.apiUrl${authConfig.v2basePath}/nodes/$node/qemu/$vmId/config")
             log.debug("POST body is: $opts.body")
             sleep(10000)
             def results = client.callJsonApi(


### PR DESCRIPTION
## Summary
- remove an extraneous debug line in ProxmoxApiComputeUtil
- keep a single `apiPath` definition in `actionVMStatus`

## Testing
- `./gradlew test` *(fails: No route to host)*