### PR TITLE
Fix log messages in VirtualImageLocationSync

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/sync/VirtualImageLocationSync.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/sync/VirtualImageLocationSync.groovy
@@ -78,9 +78,9 @@ class VirtualImageLocationSync {
             }.start()
 
         } catch (e) {
-            log.error("Error in VirtualImageSync execute : ${e}", e)
+            log.error("Error in VirtualImageLocationSync execute : ${e}", e)
         }
-        log.debug("Execute VirtualImageSync COMPLETED: ${cloud.id}")
+        log.debug("Execute VirtualImageLocationSync COMPLETED: ${cloud.id}")
     }
 
 


### PR DESCRIPTION
## Summary
- correct log messages in VirtualImageLocationSync

## Testing
- `./gradlew test` *(fails: No route to host)*