### PR TITLE
Fix rollbackSnapshot RequestOptions class

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiComputeUtil.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiComputeUtil.groovy
@@ -1335,7 +1335,7 @@ class ProxmoxApiComputeUtil {
 
             String path = "${authConfig.v2basePath}/nodes/${nodeId}/qemu/${vmId}/snapshot/${snapshotName}/rollback"
             
-            def opts = new HttpApiClient.Request.RequestOptions( // Corrected typo here
+            def opts = new HttpApiClient.RequestOptions(
                 headers: [
                     'Content-Type': 'application/json',
                     'Cookie': "PVEAuthCookie=${tokenCfg.token}",


### PR DESCRIPTION
## Summary
- fix incorrect `HttpApiClient` class reference for snapshot rollback

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*