### PR TITLE
Fix return type for instance config method

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupRestoreProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxBackupRestoreProvider.groovy
@@ -183,9 +183,9 @@ class ProxmoxBackupRestoreProvider implements BackupRestoreProvider {
     }
 
     @Override
-    Map<String,Object> getBackupRestoreInstanceConfig(BackupResult backupResult, Instance instance, Map config, Map opts) {
-        // Return an empty config map; override if provider needs specific values
-        return [:]
+    ServiceResponse<Map<String,Object>> getBackupRestoreInstanceConfig(BackupResult backupResult, Instance instance, Map config, Map opts) {
+        // Return an empty config map wrapped in a ServiceResponse; override if provider needs specific values
+        return ServiceResponse.success([:])
     }
 
     @Override


### PR DESCRIPTION
## Summary
- return a ServiceResponse for instance config to satisfy BackupRestoreProvider interface

## Testing
- `./gradlew test` *(fails: No route to host)*