### PR TITLE
Fix build dependencies for Morpheus plugin tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,32 +34,33 @@ repositories {
 }
 
 configurations {
-	provided
+    provided
 }
 
 dependencies {
-	provided "com.morpheusdata:morpheus-plugin-api:$morpheusApiVersion"
-	
-	provided "org.codehaus.groovy:groovy-all:$groovyVersion"
-	implementation 'commons-beanutils:commons-beanutils:1.9.3'
-	implementation "org.slf4j:slf4j-api:$slf4jVersion"
-	implementation "org.slf4j:slf4j-parent:$slf4jVersion"
-	implementation 'commons-net:commons-net:3.6'
-	implementation 'com.jcraft:jsch:0.1.55'
+    // Morpheus Plugin SDK provided at compile time
+    provided "com.morpheusdata:morpheus-plugin-api:$morpheusApiVersion"
+    provided "org.codehaus.groovy:groovy-all:$groovyVersion"
 
-	// Include morpheus-core and it's dependencies
-	testImplementation 'io.reactivex.rxjava3:rxjava:3.1.7'
-	testImplementation 'org.apache.httpcomponents:httpclient:4.5.3'
-	testImplementation 'org.apache.httpcomponents:httpcore:4.4.5'
-	testImplementation "org.slf4j:slf4j-parent:$slf4jVersion"
+    implementation 'commons-beanutils:commons-beanutils:1.9.3'
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "org.slf4j:slf4j-parent:$slf4jVersion"
+    implementation 'commons-net:commons-net:3.6'
+    implementation 'com.jcraft:jsch:0.1.55'
 
-	testImplementation "org.codehaus.groovy:groovy-all:$groovyVersion"
-	testImplementation 'net.bytebuddy:byte-buddy:1.9.3'
-	testImplementation 'org.objenesis:objenesis:2.6'
-	testImplementation platform("org.spockframework:spock-bom:$spockVersion")
-	testImplementation "org.spockframework:spock-core"
-	testImplementation "org.spockframework:spock-junit4"  // you can remove this if your code does not rely on old JUnit 4 rules
-	testImplementation 'cglib:cglib-nodep:3.2.12'
+    // Testing
+    testImplementation "com.morpheusdata:morpheus-plugin-api:$morpheusApiVersion"
+    testImplementation 'io.reactivex.rxjava3:rxjava:3.1.7'
+    testImplementation 'org.apache.httpcomponents:httpclient:4.5.3'
+    testImplementation 'org.apache.httpcomponents:httpcore:4.4.5'
+    testImplementation "org.slf4j:slf4j-parent:$slf4jVersion"
+    testImplementation "org.codehaus.groovy:groovy-all:$groovyVersion"
+    testImplementation 'net.bytebuddy:byte-buddy:1.9.3'
+    testImplementation 'org.objenesis:objenesis:2.6'
+    testImplementation platform("org.spockframework:spock-bom:$spockVersion")
+    testImplementation "org.spockframework:spock-core"
+    testImplementation "org.spockframework:spock-junit4"  // remove if not needed
+    testImplementation 'cglib:cglib-nodep:3.2.12'
 
 }
 

--- a/src/test/groovy/com/morpheusdata/proxmox/ve/sync/VMSyncSpec.groovy
+++ b/src/test/groovy/com/morpheusdata/proxmox/ve/sync/VMSyncSpec.groovy
@@ -13,7 +13,7 @@ import com.morpheusdata.model.projection.ComputeServerIdentityProjection
 import com.morpheusdata.proxmox.ve.ProxmoxVePlugin
 import com.morpheusdata.proxmox.ve.util.ProxmoxApiComputeUtil
 import groovy.json.JsonOutput
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import spock.lang.Specification
 import spock.lang.Subject
 


### PR DESCRIPTION
## Summary
- add Morpheus Plugin API to test classpath
- align tests with RxJava 3

## Testing
- `./gradlew test --no-daemon --offline` *(fails: No route to host)*