### PR TITLE
Add VM migration support

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeOptionSourceProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeOptionSourceProvider.groovy
@@ -42,7 +42,7 @@ class ProxmoxVeOptionSourceProvider extends AbstractOptionSourceProvider {
 
     @Override
     List<String> getMethodNames() {
-        return new ArrayList<String>(['proxmoxVeProvisionImage', 'proxmoxVeNode'])
+        return new ArrayList<String>(['proxmoxVeProvisionImage', 'proxmoxVeNode', 'proxmoxVeDestinationNode'])
     }
 
 
@@ -67,6 +67,16 @@ class ProxmoxVeOptionSourceProvider extends AbstractOptionSourceProvider {
 
         log.error("FOUND ${options.size()} ComputeServer Nodes...")
         return options
+    }
+
+    /**
+     * Option source that lists available Proxmox nodes for VM migration.
+     * Currently returns the same data as {@link #proxmoxVeNode(java.lang.Object)}.
+     * Additional filtering (e.g. removing the source node) can be handled by the caller.
+     */
+    def proxmoxVeDestinationNode(args) {
+        log.debug "proxmoxVeDestinationNode: ${args}"
+        return proxmoxVeNode(args)
     }
 
 

--- a/src/main/resources/scribe/proxmox-option-types.scribe
+++ b/src/main/resources/scribe/proxmox-option-types.scribe
@@ -34,3 +34,15 @@ resource "option-type" "proxmox-nodes" {
   required = true
   optionSource = "proxmoxVeNode"
 }
+
+resource "option-type" "proxmox-migration-node" {
+  name = "destinationNode"
+  code = "proxmox.migrate.node"
+  fieldName = "destinationNode"
+  fieldContext = "config"
+  fieldLabel = "Destination Node"
+  type = "select"
+  displayOrder = 103
+  required = true
+  optionSource = "proxmoxVeDestinationNode"
+}


### PR DESCRIPTION
## Summary
- add new option source and option-type for selecting Proxmox destination nodes
- implement `migrateVm` API call
- expose migrate VM operation in cloud provider and update VM record after migration

## Testing
- `./gradlew test` *(fails: No route to host)*