### PR TITLE
Add VLAN and OVS options to network provider

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeCloudProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeCloudProvider.groovy
@@ -180,7 +180,7 @@ class ProxmoxVeCloudProvider implements CloudProvider {
 				dhcpServerEditable: true,
 				dnsEditable       : true,
 				gatewayEditable   : true,
-				vlanIdEditable    : false,
+                                vlanIdEditable    : true,
 				canAssignPool     : true,
 				name              : 'Proxmox VE Bridge Network',
 				hasNetworkServer  : true,


### PR DESCRIPTION
## Summary
- support vlan tagging and NAT/bridge/OVS settings
- expose VLAN/NAT/OVS option types in the network UI
- pass new options when creating or updating networks
- allow vlanId to be edited by default

## Testing
- `./gradlew test` *(fails: No route to host)*