### PR TITLE
Add instance size option source

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeOptionSourceProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeOptionSourceProvider.groovy
@@ -42,7 +42,7 @@ class ProxmoxVeOptionSourceProvider extends AbstractOptionSourceProvider {
 
     @Override
     List<String> getMethodNames() {
-        return new ArrayList<String>(['proxmoxVeProvisionImage', 'proxmoxVeNode', 'proxmoxVeDestinationNode'])
+        return new ArrayList<String>(['proxmoxVeProvisionImage', 'proxmoxVeNode', 'proxmoxVeDestinationNode', 'proxmoxVeInstanceSizes'])
     }
 
 
@@ -132,5 +132,19 @@ class ProxmoxVeOptionSourceProvider extends AbstractOptionSourceProvider {
 
         log.error("FOUND ${options.size()} VirtualImages...")
         return options
+    }
+
+    /**
+     * Option source supplying a few canned instance sizes for quick selection
+     * during provisioning. These correlate to small, medium and large sizes
+     * commonly used when no cloud specific plans exist.
+     */
+    def proxmoxVeInstanceSizes(args) {
+        log.debug "proxmoxVeInstanceSizes called"
+        return [
+                [name: 'Small - 1 vCPU / 2GB RAM / 20GB Disk', value: 'small', cores: 1, memory: 2048, disk: 20],
+                [name: 'Medium - 2 vCPU / 4GB RAM / 40GB Disk', value: 'medium', cores: 2, memory: 4096, disk: 40],
+                [name: 'Large - 4 vCPU / 8GB RAM / 80GB Disk', value: 'large', cores: 4, memory: 8192, disk: 80]
+        ]
     }
 }

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeProvisionProvider.groovy
@@ -126,9 +126,22 @@ class ProxmoxVeProvisionProvider extends AbstractProvisionProvider implements Vm
 	 * Provides a Collection of OptionType inputs that need to be made available to various provisioning Wizards
 	 * @return Collection of OptionTypes
 	 */
-	@Override
-	Collection<OptionType> getOptionTypes() {
-		def options = []
+        @Override
+        Collection<OptionType> getOptionTypes() {
+                def options = []
+
+                options << new OptionType(
+                                name: 'Instance Size',
+                                code: 'proxmox-instance-size',
+                                category:'provisionType.proxmox.custom',
+                                inputType: OptionType.InputType.SELECT,
+                                fieldName: 'servicePlan',
+                                fieldContext: 'config',
+                                fieldLabel: 'Instance Size',
+                                displayOrder: 0,
+                                required: true,
+                                optionSource: 'proxmoxVeInstanceSizes'
+                )
 /*
 		options << new OptionType(
 				name: 'skip agent install',

--- a/src/main/resources/scribe/proxmox-instance-types.scribe
+++ b/src/main/resources/scribe/proxmox-instance-types.scribe
@@ -47,7 +47,7 @@ resource "instance-type" "proxmox-provision-provider" {
   pluginIconHidpiPath     = "proxmox-logo-stacked-color.svg"
   pluginIconDarkPath      = "proxmox-full-lockup-inverted-color.svg"
   pluginIconDarkHidpiPath = "proxmox-logo-stacked-inverted-color.svg"
-  optionTypes             = ["instanceType.proxmox.image", "instanceType.proxmox.node"]
+  optionTypes             = ["instanceType.proxmox.image", "instanceType.proxmox.node", "instanceType.proxmox.plan"]
 }
 
 

--- a/src/main/resources/scribe/proxmox-option-types.scribe
+++ b/src/main/resources/scribe/proxmox-option-types.scribe
@@ -46,3 +46,15 @@ resource "option-type" "proxmox-migration-node" {
   required = true
   optionSource = "proxmoxVeDestinationNode"
 }
+
+resource "option-type" "proxmox-instance-size" {
+  name         = "Instance Size"
+  code         = "instanceType.proxmox.plan"
+  fieldName    = "servicePlan"
+  fieldContext = "config"
+  fieldLabel   = "Instance Size"
+  type         = "select"
+  displayOrder = 104
+  required     = true
+  optionSource = "proxmoxVeInstanceSizes"
+}


### PR DESCRIPTION
## Summary
- add an option source for default Proxmox instance sizes
- wire the option source up to the provisioning provider as a `servicePlan` selector
- seed the new option type and attach it to the instance type

## Testing
- `./gradlew test` *(fails: could not download gradle wrapper)*