### PR TITLE
Improve Proxmox provisioning logs

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeProvisionProvider.groovy
@@ -359,10 +359,14 @@ class ProxmoxVeProvisionProvider extends AbstractProvisionProvider implements Vm
 		server.cloud = cloud
 		server = saveAndGet(server)
 
-		log.info("Provisioning/cloning: ${workload.getInstance().name} from Image Id: $imageExternalId on node: $nodeId")
-		log.info("Provisioning/cloning: ${workload.getInstance().name} with $server.coresPerSocket cores and $server.maxMemory memory")
-		ServiceResponse rtnClone = ProxmoxApiComputeUtil.cloneTemplate(client, authConfig, imageExternalId, workload.getInstance().name, nodeId, server.maxCores, server.maxMemory)
-		log.debug("VM Clone done. Results: $rtnClone")
+                log.info("Cloning template '${virtualImage?.name}' (ID: ${imageExternalId}) to instance '${workload.getInstance().name}' on node ${nodeId}")
+                log.info("Clone spec: ${server.coresPerSocket} cores, ${server.maxMemory} memory")
+                ServiceResponse rtnClone = ProxmoxApiComputeUtil.cloneTemplate(client, authConfig, imageExternalId, workload.getInstance().name, nodeId, server.maxCores, server.maxMemory)
+                if(rtnClone.success) {
+                        log.info("Clone request successful for VM ID ${rtnClone.data?.vmId}")
+                } else {
+                        log.error("Clone API error for template ${imageExternalId} on node ${nodeId}: ${rtnClone.msg}")
+                }
 
 		server.internalId = rtnClone.data.vmId
 		server.externalId = rtnClone.data.vmId

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiUtil.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiUtil.groovy
@@ -34,7 +34,11 @@ class ProxmoxApiUtil {
         while(attempt < maxAttempts) {
             attempt++
             try {
+                log.info("Calling ${method} ${apiUrl}${path}")
                 resp = client.callJsonApi(apiUrl, path, queryParams, body, opts, method)
+                if(!resp?.success) {
+                    log.error("API ${method} ${path} failed - status: ${resp?.statusCode}, msg: ${resp?.msg ?: resp?.content}")
+                }
                 if(resp?.success || !isTransientFailure(resp) || attempt >= maxAttempts) {
                     return resp
                 }


### PR DESCRIPTION
## Summary
- log template name, node and clone result during provisioning
- log each Proxmox API call in `ProxmoxApiUtil`

## Testing
- `./gradlew test` *(fails: No route to host)*