### PR TITLE
Add Proxmox VM console support

### DIFF
--- a/src/main/groovy/com/morpheusdata/model/ConsoleAccess.groovy
+++ b/src/main/groovy/com/morpheusdata/model/ConsoleAccess.groovy
@@ -1,0 +1,18 @@
+package com.morpheusdata.model
+
+/**
+ * Minimal representation of a console access descriptor used for tests.
+ * This is a simplified stand-in for the real Morpheus model class.
+ */
+class ConsoleAccess {
+    String consoleType
+    String targetHost
+    Integer port
+    String ticket
+    String webSocketUrl
+
+    Map toMap() {
+        [consoleType: consoleType, targetHost: targetHost, port: port,
+         ticket: ticket, webSocketUrl: webSocketUrl]
+    }
+}


### PR DESCRIPTION
## Summary
- enable toggle for console access in cloud options
- advertise console access capability
- implement VM console details via Proxmox VNC proxy
- add a stub ConsoleAccess model so code compiles without Morpheus SDK

## Testing
- `./gradlew clean build --refresh-dependencies` *(fails: No route to host)*