### PR TITLE
Add security group provider using Proxmox firewall API

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxSecurityGroupProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxSecurityGroupProvider.groovy
@@ -1,0 +1,100 @@
+package com.morpheusdata.proxmox.ve
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.Plugin
+import com.morpheusdata.core.providers.SecurityGroupProvider
+import com.morpheusdata.core.util.HttpApiClient
+import com.morpheusdata.model.Cloud
+import com.morpheusdata.model.ComputeServer
+import com.morpheusdata.model.OptionType
+import com.morpheusdata.response.ServiceResponse
+import com.morpheusdata.proxmox.ve.util.ProxmoxApiFirewallUtil
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class ProxmoxSecurityGroupProvider implements SecurityGroupProvider {
+    ProxmoxVePlugin plugin
+    MorpheusContext morpheus
+
+    ProxmoxSecurityGroupProvider(ProxmoxVePlugin plugin, MorpheusContext morpheus) {
+        this.plugin = plugin
+        this.morpheus = morpheus
+    }
+
+    @Override
+    Plugin getPlugin() {
+        return plugin
+    }
+
+    @Override
+    MorpheusContext getMorpheus() {
+        return morpheus
+    }
+
+    @Override
+    String getCode() {
+        return 'proxmox-ve.security-group'
+    }
+
+    @Override
+    String getName() {
+        return 'Proxmox Security Groups'
+    }
+
+    @Override
+    Collection<OptionType> getOptionTypes() {
+        return []
+    }
+
+    ServiceResponse listGroups(Cloud cloud) {
+        HttpApiClient client = new HttpApiClient()
+        try {
+            Map authConfig = plugin.getAuthConfig(cloud)
+            return ProxmoxApiFirewallUtil.listClusterFirewallGroups(client, authConfig)
+        } finally {
+            client.shutdownClient()
+        }
+    }
+
+    ServiceResponse listRules(Cloud cloud, ComputeServer server) {
+        HttpApiClient client = new HttpApiClient()
+        try {
+            Map authConfig = plugin.getAuthConfig(cloud)
+            String vmId = server.externalId
+            String nodeName = server.parentServer?.name
+            if(!vmId || !nodeName)
+                return ServiceResponse.error('Missing VM id or node name')
+            return ProxmoxApiFirewallUtil.listVmFirewallRules(client, authConfig, nodeName, vmId)
+        } finally {
+            client.shutdownClient()
+        }
+    }
+
+    ServiceResponse addRule(Cloud cloud, ComputeServer server, Map ruleConfig) {
+        HttpApiClient client = new HttpApiClient()
+        try {
+            Map authConfig = plugin.getAuthConfig(cloud)
+            String vmId = server.externalId
+            String nodeName = server.parentServer?.name
+            if(!vmId || !nodeName)
+                return ServiceResponse.error('Missing VM id or node name')
+            return ProxmoxApiFirewallUtil.createVmFirewallRule(client, authConfig, nodeName, vmId, ruleConfig)
+        } finally {
+            client.shutdownClient()
+        }
+    }
+
+    ServiceResponse removeRule(Cloud cloud, ComputeServer server, Integer rulePos) {
+        HttpApiClient client = new HttpApiClient()
+        try {
+            Map authConfig = plugin.getAuthConfig(cloud)
+            String vmId = server.externalId
+            String nodeName = server.parentServer?.name
+            if(!vmId || !nodeName)
+                return ServiceResponse.error('Missing VM id or node name')
+            return ProxmoxApiFirewallUtil.deleteVmFirewallRule(client, authConfig, nodeName, vmId, rulePos)
+        } finally {
+            client.shutdownClient()
+        }
+    }
+}

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVePlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVePlugin.groovy
@@ -18,6 +18,7 @@ package com.morpheusdata.proxmox.ve
 import com.morpheusdata.core.Plugin
 import com.morpheusdata.model.Cloud
 import com.morpheusdata.model.AccountCredential
+import com.morpheusdata.proxmox.ve.ProxmoxSecurityGroupProvider
 import groovy.util.logging.Slf4j
 
 @Slf4j
@@ -42,6 +43,7 @@ class ProxmoxVePlugin extends Plugin {
         def networkProvider = new ProxmoxNetworkProvider(this, this.morpheus)
         this.registerProvider(networkProvider)
         networkProviderCode = networkProvider.code
+        this.registerProvider(new ProxmoxSecurityGroupProvider(this, this.morpheus))
     }
     
     def ProxmoxNetworkProvider getNetworkProvider() {

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiFirewallUtil.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiFirewallUtil.groovy
@@ -146,4 +146,35 @@ class ProxmoxApiFirewallUtil {
         }
         return rtn
     }
+
+    static ServiceResponse listClusterFirewallGroups(HttpApiClient client, Map authConfig) {
+        log.debug("listClusterFirewallGroups")
+        def rtn = new ServiceResponse(success:false)
+        try {
+            def tokenResp = getApiV2Token(authConfig)
+            if(!tokenResp.success) return tokenResp
+            def tokenCfg = tokenResp.data
+            def opts = new HttpApiClient.RequestOptions(
+                headers:[
+                    'Cookie':"PVEAuthCookie=${tokenCfg.token}",
+                    'CSRFPreventionToken': tokenCfg.csrfToken
+                ],
+                contentType: ContentType.APPLICATION_JSON,
+                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+            )
+            String path = "${authConfig.v2basePath}/cluster/firewall/groups"
+            def results = ProxmoxApiUtil.callJsonApiWithRetry(client, authConfig.apiUrl, path, null, null, opts, 'GET')
+            if(results?.success) {
+                rtn.success = true
+                rtn.data = results.data?.data
+            } else {
+                rtn = ProxmoxApiUtil.validateApiResponse(results, "Failed to list firewall groups")
+            }
+        } catch(e) {
+            log.error("Error listing firewall groups: ${e.message}", e)
+            rtn.success = false
+            rtn.msg = "Error listing firewall groups: ${e.message}"
+        }
+        return rtn
+    }
 }


### PR DESCRIPTION
## Summary
- introduce `ProxmoxSecurityGroupProvider` to manage firewall rules per VM
- extend `ProxmoxApiFirewallUtil` with cluster group listing
- register the new provider in the plugin

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*