### PR TITLE
Implement cluster sync support in Proxmox plugin

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeCloudProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeCloudProvider.groovy
@@ -4,6 +4,7 @@ import com.morpheusdata.proxmox.ve.sync.DatastoreSync
 import com.morpheusdata.proxmox.ve.sync.HostSync
 import com.morpheusdata.proxmox.ve.sync.NetworkSync
 import com.morpheusdata.proxmox.ve.sync.VirtualImageLocationSync
+import com.morpheusdata.proxmox.ve.sync.ClusterSync
 import com.morpheusdata.core.MorpheusContext
 import com.morpheusdata.core.Plugin
 import com.morpheusdata.core.providers.CloudProvider
@@ -389,8 +390,9 @@ class ProxmoxVeCloudProvider implements CloudProvider {
 		HttpApiClient client = new HttpApiClient()
 		try {
 			log.debug("Synchronizing hosts, datastores, networks, VMs and virtual images...")
-			(new HostSync(plugin, cloudInfo, client)).execute()
-			(new DatastoreSync(plugin, cloudInfo, client)).execute()
+                        (new HostSync(plugin, cloudInfo, client)).execute()
+                        (new ClusterSync(plugin, cloudInfo, client)).execute()
+                        (new DatastoreSync(plugin, cloudInfo, client)).execute()
 			(new NetworkSync(plugin, cloudInfo, client)).execute()
 			(new VMSync(plugin, cloudInfo, client, this)).execute()
 			(new VirtualImageLocationSync(plugin, cloudInfo, client, this)).execute()
@@ -489,9 +491,18 @@ class ProxmoxVeCloudProvider implements CloudProvider {
 	 * @return Boolean
 	 */
 	@Override
-	Boolean hasBareMetal() {
-		return false
-	}
+        Boolean hasBareMetal() {
+                return false
+        }
+
+        /**
+         * Returns whether the cloud supports clusters / HA groups
+         * @return Boolean
+         */
+        @Override
+        Boolean hasClusters() {
+                return true
+        }
 
 	/**
 	 * Indicates if the cloud supports cloud-init. Returning true will allow configuration of the Cloud

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/sync/ClusterSync.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/sync/ClusterSync.groovy
@@ -1,0 +1,97 @@
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.util.HttpApiClient
+import com.morpheusdata.core.util.SyncTask
+import com.morpheusdata.model.Cloud
+import com.morpheusdata.model.CloudPool
+import com.morpheusdata.model.projection.CloudPoolIdentityProjection
+import com.morpheusdata.proxmox.ve.ProxmoxVePlugin
+import com.morpheusdata.proxmox.ve.util.ProxmoxApiComputeUtil
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class ClusterSync {
+
+    private Cloud cloud
+    private MorpheusContext context
+    private ProxmoxVePlugin plugin
+    private HttpApiClient apiClient
+    private Map authConfig
+
+    ClusterSync(ProxmoxVePlugin plugin, Cloud cloud, HttpApiClient apiClient) {
+        this.@plugin = plugin
+        this.@cloud = cloud
+        this.@context = plugin.morpheus
+        this.@apiClient = apiClient
+        this.@authConfig = plugin.getAuthConfig(cloud)
+    }
+
+    def execute() {
+        log.debug "Execute ClusterSync for cloud ${cloud?.id}"
+        def resp = ProxmoxApiComputeUtil.listProxmoxClusters(apiClient, authConfig)
+        if(!resp.success) {
+            log.error "Error listing clusters: ${resp.msg}"
+            return
+        }
+        def cloudItems = resp.data ?: []
+        def domainRecords = context.async.cloud.pool.listSyncProjections(cloud.id)
+
+        SyncTask<CloudPoolIdentityProjection, Map, CloudPool> syncTask = new SyncTask<>(domainRecords, cloudItems)
+        syncTask.addMatchFunction { CloudPoolIdentityProjection domain, Map item ->
+            domain.externalId == item.name
+        }.onAdd { addItems ->
+            addClusters(addItems)
+        }.onDelete { removeItems ->
+            removeClusters(removeItems)
+        }.withLoadObjectDetails { updateItems ->
+            Map<Long, SyncTask.UpdateItemDto<CloudPoolIdentityProjection, Map>> updateItemMap = updateItems.collectEntries { [(it.existingItem.id): it] }
+            context.async.cloud.pool.listById(updateItems.collect { it.existingItem.id }).map { CloudPool pool ->
+                new SyncTask.UpdateItem<CloudPool, Map>(existingItem: pool, masterItem: updateItemMap[pool.id].masterItem)
+            }
+        }.onUpdate { updateItems ->
+            updateClusters(updateItems)
+        }.start()
+    }
+
+    private addClusters(Collection<Map> addItems) {
+        def adds = []
+        addItems?.each { Map item ->
+            CloudPool pool = new CloudPool(
+                cloud      : cloud,
+                account    : cloud.owner,
+                name       : item.name,
+                externalId : item.name,
+                description: (item.roles ?: []).join(', '),
+                refType    : 'ComputeZone',
+                refId      : cloud.id,
+                code       : "proxmox.cluster.${item.name}"
+            )
+            adds << pool
+        }
+        if(adds)
+            context.async.cloud.pool.create(adds).blockingGet()
+    }
+
+    private updateClusters(List<SyncTask.UpdateItem<CloudPool, Map>> updateItems) {
+        updateItems?.each { updateItem ->
+            CloudPool pool = updateItem.existingItem
+            Map item = updateItem.masterItem
+            boolean save = false
+            if(pool.name != item.name) {
+                pool.name = item.name
+                save = true
+            }
+            String desc = (item.roles ?: []).join(', ')
+            if(pool.description != desc) {
+                pool.description = desc
+                save = true
+            }
+            if(save)
+                context.async.cloud.pool.save([pool]).blockingGet()
+        }
+    }
+
+    private removeClusters(List<CloudPoolIdentityProjection> removeItems) {
+        if(removeItems)
+            context.async.cloud.pool.bulkRemove(removeItems).blockingGet()
+    }
+}


### PR DESCRIPTION
## Summary
- add `ClusterSync` to discover clusters/HA groups via Proxmox API
- execute `ClusterSync` during cloud refresh cycle
- expose new `hasClusters()` capability in the cloud provider

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*
- `./gradlew classes --no-daemon` *(fails: No route to host)*