### PR TITLE
Add configurable SSL verification

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxNetworkProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxNetworkProvider.groovy
@@ -261,7 +261,7 @@ class ProxmoxNetworkProvider implements NetworkProvider, CloudInitializationProv
                                         ],
                                         body: body,
                                         contentType: ContentType.APPLICATION_JSON,
-                                        ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                                        ignoreSSL: authConfig.ignoreSSL
                                 )
 
                                 def results = client.callJsonApi(authConfig.apiUrl,
@@ -353,7 +353,7 @@ class ProxmoxNetworkProvider implements NetworkProvider, CloudInitializationProv
                                         ],
                                         body: body,
                                         contentType: ContentType.APPLICATION_JSON,
-                                        ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                                        ignoreSSL: authConfig.ignoreSSL
                                 )
 
                                 def results = client.callJsonApi(authConfig.apiUrl,
@@ -423,7 +423,7 @@ class ProxmoxNetworkProvider implements NetworkProvider, CloudInitializationProv
                                                 'CSRFPreventionToken': tokenCfg.csrfToken
                                         ],
                                         contentType: ContentType.APPLICATION_JSON,
-                                        ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                                        ignoreSSL: authConfig.ignoreSSL
                                 )
 
                                 def results = client.callJsonApi(authConfig.apiUrl,

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeCloudProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVeCloudProvider.groovy
@@ -148,6 +148,17 @@ class ProxmoxVeCloudProvider implements CloudProvider {
                                 defaultValue: false,
                                 required: false
                 )
+                options << new OptionType(
+                                name: 'Verify SSL Certificates',
+                                code: 'proxmox-verify-ssl',
+                                displayOrder: 5,
+                                fieldContext: 'config',
+                                fieldLabel: 'Verify SSL Certificates',
+                                fieldName: 'verifySsl',
+                                inputType: OptionType.InputType.CHECKBOX,
+                                defaultValue: !ProxmoxSslUtil.IGNORE_SSL,
+                                required: false
+                )
 /*		options << new OptionType(
 				name: 'Proxmox Token',
 				code: 'proxmox-token',
@@ -941,7 +952,7 @@ class ProxmoxVeCloudProvider implements CloudProvider {
                                ],
                                body: body,
                                contentType: ContentType.APPLICATION_JSON,
-                               ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                               ignoreSSL: authConfig.ignoreSSL
                        )
 
                        log.debug("POST ${authConfig.apiUrl}${path} body ${body}")

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVePlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/ProxmoxVePlugin.groovy
@@ -18,6 +18,7 @@ package com.morpheusdata.proxmox.ve
 import com.morpheusdata.core.Plugin
 import com.morpheusdata.model.Cloud
 import com.morpheusdata.model.AccountCredential
+import com.morpheusdata.proxmox.ve.util.ProxmoxSslUtil
 import groovy.util.logging.Slf4j
 
 @Slf4j
@@ -55,7 +56,8 @@ class ProxmoxVePlugin extends Plugin {
                 apiUrl    : cloud.serviceUrl,
                 v2basePath: V2_BASE_PATH,
                 username  : null,
-                password  : null
+                password  : null,
+                ignoreSSL : ProxmoxSslUtil.IGNORE_SSL
         ]
 
         if(!cloud.accountCredentialLoaded) {
@@ -79,6 +81,9 @@ class ProxmoxVePlugin extends Plugin {
             rtn.password = cloud.accountCredentialData['password']
         } else {
             rtn.password = cloud.configMap.password ?: cloud.servicePassword
+        }
+        if(cloud.configMap?.containsKey('verifySsl')) {
+            rtn.ignoreSSL = !cloud.configMap.verifySsl.toString().toBoolean()
         }
         return rtn
     }

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiBackupUtil.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiBackupUtil.groovy
@@ -32,7 +32,7 @@ class ProxmoxApiBackupUtil {
                     headers: ['Content-Type':'application/x-www-form-urlencoded'],
                     body: bodyStr,
                     contentType: ContentType.APPLICATION_FORM_URLENCODED,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL // TODO: Make this configurable based on cloud settings if possible
+                    ignoreSSL: authConfig.ignoreSSL // TODO: Make this configurable based on cloud settings if possible
             )
             def results = ProxmoxApiUtil.callJsonApiWithRetry(client, authConfig.apiUrl, "${authConfig.v2basePath}/\${path}", null, null, opts, 'POST')
 
@@ -84,7 +84,7 @@ class ProxmoxApiBackupUtil {
                 ],
                 body: bodyPayload,
                 contentType: ContentType.APPLICATION_JSON, // TODO: Verify Content-Type; Proxmox might expect x-www-form-urlencoded for this operation.
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL // TODO: Make this configurable
+                ignoreSSL: authConfig.ignoreSSL // TODO: Make this configurable
             )
 
             log.info("Creating Proxmox snapshot. API POST to \${authConfig.apiUrl}\${authConfig.v2basePath}/\${path} with body: \${bodyPayload}")
@@ -122,7 +122,7 @@ class ProxmoxApiBackupUtil {
                     'Cookie': "PVEAuthCookie=\${tokenCfg.token}",
                     'CSRFPreventionToken': tokenCfg.csrfToken
                 ],
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL // TODO: Make this configurable
+                ignoreSSL: authConfig.ignoreSSL // TODO: Make this configurable
             )
 
             log.info("Deleting Proxmox snapshot. API DELETE to \${authConfig.apiUrl}\${authConfig.v2basePath}/\${path}")
@@ -175,7 +175,7 @@ class ProxmoxApiBackupUtil {
                 ],
                 body: bodyPayload, 
                 contentType: ContentType.APPLICATION_JSON, // TODO: Verify Content-Type; Proxmox might expect x-www-form-urlencoded for this operation.
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL // TODO: Make this configurable
+                ignoreSSL: authConfig.ignoreSSL // TODO: Make this configurable
             )
 
             log.info("Rolling back Proxmox snapshot. API POST to \${authConfig.apiUrl}\${authConfig.v2basePath}/\${path}")
@@ -212,7 +212,7 @@ class ProxmoxApiBackupUtil {
                     'Cookie': "PVEAuthCookie=\${tokenCfg.token}",
                     'CSRFPreventionToken': tokenCfg.csrfToken
                 ],
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Fetching Proxmox task status from \${authConfig.apiUrl}\${authConfig.v2basePath}/\${path}")

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiComputeUtil.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiComputeUtil.groovy
@@ -41,7 +41,7 @@ class ProxmoxApiComputeUtil {
                             memory: ramValue
                     ],
                     contentType: ContentType.APPLICATION_JSON,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             ]
 
             log.debug("Setting VM Compute Size $vmId on node $node...")
@@ -94,7 +94,7 @@ class ProxmoxApiComputeUtil {
                     ],
                     body     : bodyPayload,
                     contentType: ContentType.APPLICATION_JSON,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             ]
 
             String apiPath = "${authConfig.v2basePath}/nodes/$node/qemu/$vmId/config"
@@ -188,7 +188,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: body,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             ]
 
             String apiPath = "${authConfig.v2basePath}/nodes/${nodeId}/qemu/${vmId}/migrate"
@@ -231,7 +231,7 @@ class ProxmoxApiComputeUtil {
                             node: nodeId
                     ],
                     contentType: ContentType.APPLICATION_JSON,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             ]
 
             String apiPath = "${authConfig.v2basePath}/nodes/$nodeId/qemu/$vmId/status/$action"
@@ -267,7 +267,7 @@ class ProxmoxApiComputeUtil {
                     'CSRFPreventionToken': tokenCfg.csrfToken
                 ],
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             ]
             String apiPath = "${authConfig.v2basePath}/nodes/${nodeId}/status/${action}"
             log.debug("Node action POST path ${authConfig.apiUrl}${apiPath}")
@@ -299,7 +299,7 @@ class ProxmoxApiComputeUtil {
                             'CSRFPreventionToken': tokenCfg.csrfToken
                     ],
                     body: null,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL,
+                    ignoreSSL: authConfig.ignoreSSL,
                     contentType: ContentType.APPLICATION_JSON,
             ]
 
@@ -357,7 +357,7 @@ class ProxmoxApiComputeUtil {
                             template: true
                     ],
                     contentType: ContentType.APPLICATION_JSON,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             ]
 
             log.debug("Creating blank template for attaching qcow2...")
@@ -412,7 +412,7 @@ class ProxmoxApiComputeUtil {
                             'CSRFPreventionToken': tokenCfg.csrfToken
                     ],
                     contentType: ContentType.APPLICATION_JSON,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             ]
 
             log.debug("Checking VM Status after clone template $templateId to VM $vmId on node $nodeId")
@@ -476,7 +476,7 @@ class ProxmoxApiComputeUtil {
                             full: true
                     ],
                     contentType: ContentType.APPLICATION_JSON,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             ]
 
             log.debug("Cloning template $templateId to VM $name($nextId) on node $nodeId")
@@ -890,7 +890,7 @@ class ProxmoxApiComputeUtil {
                         'CSRFPreventionToken': tokenCfg.csrfToken
                     ],
                     contentType: ContentType.APPLICATION_JSON,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             )
             def results = ProxmoxApiUtil.callJsonApiWithRetry(client, authConfig.apiUrl, "${authConfig.v2basePath}/${path}", null, null, opts, 'GET')
             
@@ -945,7 +945,7 @@ class ProxmoxApiComputeUtil {
                     headers: ['Content-Type':'application/x-www-form-urlencoded'],
                     body: bodyStr,
                     contentType: ContentType.APPLICATION_FORM_URLENCODED,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             )
             def results = ProxmoxApiUtil.callJsonApiWithRetry(client, authConfig.apiUrl,"${authConfig.v2basePath}/${path}", null, null, opts, 'POST')
 
@@ -990,7 +990,7 @@ class ProxmoxApiComputeUtil {
                     headers: ['Content-Type':'application/x-www-form-urlencoded'],
                     body: bodyStr,
                     contentType: ContentType.APPLICATION_FORM_URLENCODED,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             )
             def results = ProxmoxApiUtil.callJsonApiWithRetry(client, baseUrl,"${API_BASE_PATH}/${path}", opts, 'POST')
 
@@ -1037,7 +1037,7 @@ class ProxmoxApiComputeUtil {
                     'CSRFPreventionToken': tokenCfg.csrfToken
                 ],
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
             String configPath = "${authConfig.v2basePath}/nodes/${nodeName}/qemu/${vmId}/config"
             log.debug("Getting VM config from: ${authConfig.apiUrl}${configPath}")
@@ -1097,7 +1097,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: addDiskBody,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Adding disk with POST to: ${authConfig.apiUrl}${configPath}")
@@ -1154,7 +1154,7 @@ class ProxmoxApiComputeUtil {
                     'CSRFPreventionToken': tokenCfg.csrfToken
                 ],
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
             String configPath = "${authConfig.v2basePath}/nodes/${nodeName}/qemu/${vmId}/config"
             log.debug("Getting VM config from: ${authConfig.apiUrl}${configPath}")
@@ -1214,7 +1214,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: addNicBody,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Adding NIC with POST to: ${authConfig.apiUrl}${configPath}")
@@ -1290,7 +1290,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: requestBody,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Requesting ${consoleType} console with POST to: ${authConfig.apiUrl}${apiPath}")
@@ -1371,7 +1371,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: requestBody,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Creating snapshot with POST to: ${authConfig.apiUrl}${path}")
@@ -1418,7 +1418,7 @@ class ProxmoxApiComputeUtil {
                     'Cookie': "PVEAuthCookie=${tokenCfg.token}",
                     'CSRFPreventionToken': tokenCfg.csrfToken
                 ],
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Deleting snapshot with DELETE to: ${authConfig.apiUrl}${path}")
@@ -1466,7 +1466,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: [:], // Empty body for rollback
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Rolling back snapshot with POST to: ${authConfig.apiUrl}${path}")
@@ -1525,7 +1525,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: requestBody,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Removing disk '${diskName}' from VM ${vmId} on node ${nodeName} with POST to: ${authConfig.apiUrl}${configPath}")
@@ -1588,7 +1588,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: requestBody,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Resizing disk '${diskName}' on VM ${vmId} via ${authConfig.apiUrl}${apiPath} with body ${requestBody}")
@@ -1646,7 +1646,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: requestBody,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Removing network interface '${interfaceName}' from VM ${vmId} on node ${nodeName} with POST to: ${authConfig.apiUrl}${configPath}")
@@ -1732,7 +1732,7 @@ class ProxmoxApiComputeUtil {
                 ],
                 body: requestBody,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
 
             log.debug("Updating network interface '${interfaceName}' on VM ${vmId} on node ${nodeName} with POST to: ${authConfig.apiUrl}${configPath}")
@@ -1783,7 +1783,7 @@ class ProxmoxApiComputeUtil {
                             'CSRFPreventionToken': tokenCfg.csrfToken
                     ],
                     contentType: ContentType.APPLICATION_JSON,
-                    ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                    ignoreSSL: authConfig.ignoreSSL
             ]
 
             String apiPath = "${authConfig.v2basePath}/nodes/${nodeName}/qemu/${vmId}/template"

--- a/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiFirewallUtil.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/util/ProxmoxApiFirewallUtil.groovy
@@ -29,7 +29,7 @@ class ProxmoxApiFirewallUtil {
                 headers:['Content-Type':'application/x-www-form-urlencoded'],
                 body: bodyStr,
                 contentType: ContentType.APPLICATION_FORM_URLENCODED,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
             def results = ProxmoxApiUtil.callJsonApiWithRetry(client, authConfig.apiUrl, "${authConfig.v2basePath}/${path}", null, null, opts, 'POST')
             log.debug("getApiV2Token API response raw content: ${results.content}")
@@ -65,7 +65,7 @@ class ProxmoxApiFirewallUtil {
                     'CSRFPreventionToken': tokenCfg.csrfToken
                 ],
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
             String path = "${authConfig.v2basePath}/nodes/${nodeId}/qemu/${vmId}/firewall/rules"
             def results = ProxmoxApiUtil.callJsonApiWithRetry(client, authConfig.apiUrl, path, null, null, opts, 'GET')
@@ -98,7 +98,7 @@ class ProxmoxApiFirewallUtil {
                 ],
                 body: ruleConfig,
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
             String path = "${authConfig.v2basePath}/nodes/${nodeId}/qemu/${vmId}/firewall/rules"
             def results = ProxmoxApiUtil.callJsonApiWithRetry(client, authConfig.apiUrl, path, null, null, opts, 'POST')
@@ -130,7 +130,7 @@ class ProxmoxApiFirewallUtil {
                     'CSRFPreventionToken': tokenCfg.csrfToken
                 ],
                 contentType: ContentType.APPLICATION_JSON,
-                ignoreSSL: ProxmoxSslUtil.IGNORE_SSL
+                ignoreSSL: authConfig.ignoreSSL
             )
             String path = "${authConfig.v2basePath}/nodes/${nodeId}/qemu/${vmId}/firewall/rules/${rulePos}"
             def results = ProxmoxApiUtil.callJsonApiWithRetry(client, authConfig.apiUrl, path, null, null, opts, 'DELETE')


### PR DESCRIPTION
## Summary
- allow optional SSL verification via new plugin setting
- pass cloud setting through auth config
- use cloud setting when making HTTP requests

## Testing
- `./gradlew test` *(fails: No route to host)*