### PR TITLE
Fix DatastoreSync parameter issues

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/sync/DatastoreSync.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/sync/DatastoreSync.groovy
@@ -8,7 +8,6 @@ import com.morpheusdata.core.util.SyncTask
 import com.morpheusdata.model.Account
 import com.morpheusdata.model.Cloud
 import com.morpheusdata.model.Datastore
-import com.morpheusdata.model.StorageVolume
 import com.morpheusdata.model.projection.DatastoreIdentity
 import groovy.util.logging.Slf4j
 
@@ -43,7 +42,7 @@ class DatastoreSync {
             def cloudItems = datastoreResults?.data
             def domainRecords = morpheusContext.async.cloud.datastore.listSyncProjections(cloud.id)
 
-            SyncTask<DatastoreIdentity, Map, StorageVolume> syncTask = new SyncTask<>(domainRecords, cloudItems as Collection)
+            SyncTask<DatastoreIdentity, Map, Datastore> syncTask = new SyncTask<>(domainRecords, cloudItems as Collection)
             syncTask.addMatchFunction { DatastoreIdentity domainObject, Map cloudItem ->
                 domainObject.externalId == cloudItem.storage
             }.withLoadObjectDetails { List<SyncTask.UpdateItemDto<DatastoreIdentity, Map>> updateItems ->
@@ -56,7 +55,7 @@ class DatastoreSync {
             }.onUpdate { List<SyncTask.UpdateItem<Datastore, Map>> updateItems ->
                 updateMatchedDatastores(cloud, updateItems)
             }.onDelete { removeItems ->
-                removeMissingDatastores(cloud, removeItems)
+                removeMissingDatastores(removeItems)
             }.start()
 
         }


### PR DESCRIPTION
## Summary
- correct generics for `SyncTask` in `DatastoreSync`
- remove unused import
- fix delete handler invocation to match method signature

## Testing
- `./gradlew test` *(fails: unable to download Gradle due to network)*