### PR TITLE
Fix host sync fields for Morpheus

### DIFF
--- a/src/main/groovy/com/morpheusdata/proxmox/ve/sync/HostSync.groovy
+++ b/src/main/groovy/com/morpheusdata/proxmox/ve/sync/HostSync.groovy
@@ -139,8 +139,8 @@ class HostSync {
                 doUpdate = true
             }
 
-            if (cloudItem.externalIp != existingItem.externalIp) {
-                existingItem.setExternalIp(cloudItem.externalIp)
+            if (cloudItem.ipAddress != existingItem.externalIp) {
+                existingItem.setExternalIp(cloudItem.ipAddress)
                 doUpdate = true
             }
 


### PR DESCRIPTION
## Summary
- pull hypervisor data from `cluster/resources` to capture node metrics
- include `node`, `status`, and disk/memory fields when listing nodes
- update host sync to use `ipAddress` field when updating hosts

## Testing
- `./gradlew test` *(fails: No route to host)*